### PR TITLE
Convert Next Steps: Merge app.json into exp.json

### DIFF
--- a/src/project/Convert.js
+++ b/src/project/Convert.js
@@ -135,9 +135,10 @@ async function installAndInstructAsync(projectDir, unsupportedPackagesUsed) {
 1. If you have separate index.ios.js and index.android.js files, you'll need to create a main.js file that contains \`require('./index');\`. Also set \`"main": "main.js"\` in package.json.
 2. Find your AppRegistry.registerComponent('YourApplicationName', () => YourRootComponent) call and replace it with Expo.registerRootComponent(YourRootComponent) (you will need to import Expo from 'expo').
 3. Upload your app icon somewhere on the web and add it the newly created exp.json file, in the iconUrl and loading.iconUrl fields.
-4. Delete your 'android' and 'ios' directories if you have them -- you no longer need to compile any native code to run your app.
-5. ${showCompatibilityMessage(unsupportedPackagesUsed)}
-6. Open your app in XDE and run it, fix bugs as they arise.
+4. Merge the contents of app.json and exp.json into one single file, which will just be exp.json. Delete app.json after this point.
+5. Delete your 'android' and 'ios' directories if you have them -- you no longer need to compile any native code to run your app.
+6. ${showCompatibilityMessage(unsupportedPackagesUsed)}
+7. Open your app in XDE and run it, fix bugs as they arise.
 `;
   console.log(nextStepMessage);
   fse.outputFileSync(nextStepMessagePath, nextStepMessage);


### PR DESCRIPTION
This PR is a follow-up to the issue reported in [this blog post](https://forums.expo.io/t/missing-app-json-file/507/5). After converting an existing React-Native project to Expo using `exp convert`, the following error will occur in the XDE:

> Error: Missing app.json. See https://docs.expo.io/

As reported in the blog post, the solution is to remove `app.json` after merging its contents to `exp.json`. It would be nice if this requirement (to not have `app.json` in the project anymore after conversion) was more explicitly stated. It would be especially helpful for those newer to the React-Native and Expo stacks like myself.

Although a great long-term fix would be to support automatic merging logic of `app.json` to `exp.json` (with a fallback to manual merge if there is a conflict), I think just simply mentioning the need for the merge is a great patch in the short term. I hope that this PR helps.