### PR TITLE
Relax React peer dep requirement to 15.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,10 +121,10 @@
     "jest": "^19.0.2",
     "mock-fs": "^3.12.1",
     "promise-print": "^2.3.0",
-    "react": "16.0.0-alpha.12",
+    "react": "~15.4.2",
     "rimraf": "^2.5.4"
   },
   "peerDependencies": {
-    "react": "16.0.0-alpha.12"
+    "react": ">=15.4.2"
   }
 }


### PR DESCRIPTION
This Pull Request relaxes requirements to React peer dependency version. Since `xdl` do not use anything React 16.x specific and the first Expo SDK - Expo SDK 14 depends on React 15.4.2 there is a possibility for the `xdl` to support all the Expo SDKs starting from the very first by relaxing requirement to React version to `15.4.2`.