### PR TITLE
Update osascript to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@expo/spawn-async": "^1.2.8",
     "@exponent/json-file": "^5.3.0",
     "@exponent/node-auth0": "^2.6.0",
-    "@exponent/osascript": "^1.6.4",
+    "@expo/osascript": "^1.7.0",
     "analytics-node": "^2.1.0",
     "auth0-js": "^7.4.0",
     "bluebird": "^3.4.7",


### PR DESCRIPTION
This updates `osascript` to `1.7.0`. At the same time, it updates the dependency declarations to remove the following warning:

```
warning @exponent/osascript > @exponent/spawn-async@1.2.8: Please switch to @expo/spawn-async, the new name of this package. It's the same code with our new name.
```
