### PR TITLE
If Yarn exists, don't show npm version warnings

### DIFF
--- a/src/project/Doctor.js
+++ b/src/project/Doctor.js
@@ -44,10 +44,8 @@ async function _checkNpmVersionAsync(projectRoot) {
 
     try {
       let yarnVersionResponse = await spawnAsync('yarnpkg', ['--version']);
-      let yarnVersion = _.trim(yarnVersionResponse.stdout);
-
-      if (yarnVersion) {
-        return NO_ISSUES;
+      if (yarnVersionResponse.status === 0) {
+        return NO_ISSUES
       }
     } catch (e) {}
 

--- a/src/project/Doctor.js
+++ b/src/project/Doctor.js
@@ -41,6 +41,11 @@ function _isNpmVersionWithinRanges(npmVersion, ranges) {
 async function _checkNpmVersionAsync(projectRoot) {
   try {
     await Binaries.sourceBashLoginScriptsAsync();
+    let yarnVersionResponse = await spawnAsync('yarn', ['--version']);
+    let yarnVersion = _.trim(yarnVersionResponse.stdout);
+
+    if (yarnVersion) return NO_ISSUES
+
     let npmVersionResponse = await spawnAsync('npm', ['--version']);
     let npmVersion = _.trim(npmVersionResponse.stdout);
     if (

--- a/src/project/Doctor.js
+++ b/src/project/Doctor.js
@@ -41,13 +41,19 @@ function _isNpmVersionWithinRanges(npmVersion, ranges) {
 async function _checkNpmVersionAsync(projectRoot) {
   try {
     await Binaries.sourceBashLoginScriptsAsync();
-    let yarnVersionResponse = await spawnAsync('yarn', ['--version']);
-    let yarnVersion = _.trim(yarnVersionResponse.stdout);
 
-    if (yarnVersion) return NO_ISSUES
+    try {
+      let yarnVersionResponse = await spawnAsync('yarn', ['--version']);
+      let yarnVersion = _.trim(yarnVersionResponse.stdout);
+
+      if (yarnVersion) {
+        return NO_ISSUES;
+      }
+    } catch (e) {}
 
     let npmVersionResponse = await spawnAsync('npm', ['--version']);
     let npmVersion = _.trim(npmVersionResponse.stdout);
+
     if (
       semver.lt(npmVersion, MIN_NPM_VERSION) ||
       _isNpmVersionWithinRanges(npmVersion, BAD_NPM_VERSION_RANGES)

--- a/src/project/Doctor.js
+++ b/src/project/Doctor.js
@@ -43,7 +43,7 @@ async function _checkNpmVersionAsync(projectRoot) {
     await Binaries.sourceBashLoginScriptsAsync();
 
     try {
-      let yarnVersionResponse = await spawnAsync('yarn', ['--version']);
+      let yarnVersionResponse = await spawnAsync('yarnpkg', ['--version']);
       let yarnVersion = _.trim(yarnVersionResponse.stdout);
 
       if (yarnVersion) {


### PR DESCRIPTION
Hey Expo,

Let me know if there's anything I can do to help push this along. I'd really love to be able to suppress the warning message for those that use `yarn` over `npm`.

Thanks!