### PR TITLE
support https proxies

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -1303,7 +1303,7 @@ export async function startExpoServerAsync(projectRoot: string) {
       } // Get packager opts and then copy into bundleUrlPackagerOpts
       let packagerOpts = await ProjectSettings.getPackagerOptsAsync(projectRoot);
       let bundleUrlPackagerOpts = JSON.parse(JSON.stringify(packagerOpts));
-      bundleUrlPackagerOpts.urlType = 'http';
+
       if (bundleUrlPackagerOpts.hostType === 'redirect') {
         bundleUrlPackagerOpts.hostType = 'tunnel';
       }
@@ -1330,15 +1330,15 @@ export async function startExpoServerAsync(projectRoot: string) {
       );
       let path = `/${mainModuleName}.bundle?platform=${platform}&${queryParams}`;
       manifest.bundleUrl =
-        (await UrlUtils.constructBundleUrlAsync(projectRoot, bundleUrlPackagerOpts, req.hostname)) +
+        (await UrlUtils.constructBundleUrlAsync(projectRoot, bundleUrlPackagerOpts, true, req.hostname)) +
         path;
       manifest.debuggerHost = await UrlUtils.constructDebuggerHostAsync(projectRoot, req.hostname);
       manifest.mainModuleName = mainModuleName;
-      manifest.logUrl = `${await UrlUtils.constructManifestUrlAsync(
+      manifest.logUrl = await UrlUtils.constructLogUrlAsync(
         projectRoot,
-        { urlType: 'http' },
+        bundleUrlPackagerOpts,
         req.hostname
-      )}/logs`; // Resolve manifest assets to their packager URL
+      );
       await _resolveManifestAssets(
         projectRoot,
         manifest,

--- a/src/ProjectSettings.js
+++ b/src/ProjectSettings.js
@@ -15,6 +15,7 @@ let projectSettingsDefaults = {
   dev: true,
   minify: false,
   urlRandomness: null,
+  urlType: 'http',
 };
 let packagerInfoFile = 'packager-info.json';
 
@@ -35,11 +36,6 @@ export async function readAsync(projectRoot: string) {
   if (projectSettings.hostType === 'ngrok') {
     // 'ngrok' is deprecated
     projectSettings.hostType = 'tunnel';
-  }
-
-  if (projectSettings.urlType) {
-    // urlType is deprecated as a project setting
-    delete projectSettings.urlType;
   }
 
   if ('strict' in projectSettings) {


### PR DESCRIPTION
I'm trying to get Expo working within our staging environment which has an https proxy. This PR allows me to configure the react-native-scripts program to use ENV variables for the hostname and port. Previously XDL only supported plaintext http.

As best as I can tell, all changes are backwards compatible.

For example, my proxied .expo/settings.json
```json
{
  "hostType": "proxied",
  "lanType": "ip",
  "dev": true,
  "strict": false,
  "minify": false,
  "urlType": "http",
  "urlRandomness": null
}
``` 

my corresponding ENV variables:
```
EXPORT EXPO_PACKAGER_URL="expo-drive-packager.flexport.xyz"
EXPORT EXPO_SERVER_URL="expo-drive-server.flexport.xyz"
```

The NGINX proxy (non-https version)
```

server {
    listen       80;
    server_name  ~expo-drive-server.flexport\.xyz$;

    location / {
      proxy_pass          http://127.0.0.1:19000;
      proxy_set_header    Host             $host;
      proxy_set_header    X-Real-IP        $remote_addr;
      proxy_set_header    X-Forwarded-For  $proxy_add_x_forwarded_for;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection $connection_upgrade;
      proxy_read_timeout 1800;
      proxy_connect_timeout 1800;
    }
}

server {
    listen       80;
    server_name  ~expo-drive-packager.flexport\.xyz$;

    location / {
      proxy_pass          http://127.0.0.1:19000;
      proxy_set_header    Host             $host;
      proxy_set_header    X-Real-IP        $remote_addr;
      proxy_set_header    X-Forwarded-For  $proxy_add_x_forwarded_for;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection $connection_upgrade;
      proxy_read_timeout 1800;
      proxy_connect_timeout 1800;
    }
}
```
