### PR TITLE
Add assets to bundle not with asset general hash, but with fileHashes array values for each attached file

### DIFF
--- a/src/Project.js
+++ b/src/Project.js
@@ -677,7 +677,11 @@ async function _fetchAndUploadAssetsAsync(projectRoot, exp) {
     for (const asset of assets) {
       const file = asset.files && asset.files[0];
       if (asset.__packager_asset && file && fullPatterns.some(p => minimatch(file, p))) {
-        bundledAssets.add('asset_' + asset.hash + (asset.type ? '.' + asset.type : ''));
+        asset.fileHashes.forEach(hash =>
+          bundledAssets.add(
+            "asset_" + hash + (asset.type ? "." + asset.type : "")
+          )
+        );
       }
     }
     exp.bundledAssets = [...bundledAssets];


### PR DESCRIPTION
This is fix for bug `assetBundlePatterns error on Android when using sufix like image@2x.png`
https://forums.expo.io/t/assetbundlepatterns-error-on-android-when-using-sufix-like-image-2x-png/6790.

The bug was because there are could be multiple attached files in one required Asset, but only one file was added in bundle - `asset.files[0]`, and always was used asset general hash, but not this specific file hash.
These hashes could be different, in this case there will be broken unnecessary files in bundle, which is also a bug.

Asset has multiple attached files when you have image in three sizes

```
/assets/img/app-features.png
/assets/img/app-features@2x.png
/assets/img/app-features@3x.png
```

and require it like this

```
<Image source={require(‘./assets/images/app-features.png’)} />
```

In this case Asset object looks like this

<img width="981" alt="screen shot 2018-04-07 at 9 56 19 pm" src="https://user-images.githubusercontent.com/14208343/38459120-98ed8e2c-3aae-11e8-920e-1952c068f235.png">


As you see Asset general hash is different from Asset files hashes.

In this case when you do this
```
bundledAssets.add('asset_' + asset.hash + (asset.type ? '.' + asset.type : ''));
```
you will add to the bundle file `asset_2d9c23e0c8a503ad84999fc1eeb52acc.png`. But there is no file for Asset general hash and you will add broken file inside bundle.

It looks like this
<img width="1474" alt="screen shot 2018-04-07 at 10 00 42 pm" src="https://user-images.githubusercontent.com/14208343/38459179-49399096-3aaf-11e8-89b1-53feadabe917.png">

Only files with hashes specified in Asset `fileHashes` array always exist.

To fix this bug you need to go through Asset `fileHashes` array and add to the bundle files for each item in it.

To test this fix
```
git clone repo https://github.com/serhiipalash/test-assets
cd test-assets
yarn
```
then open file `/node_modules/xdl/build/Project.js` and find `_fetchAndUploadAssetsAsync` function in it.

Add logs
<img width="1163" alt="screen shot 2018-04-07 at 10 09 19 pm" src="https://user-images.githubusercontent.com/14208343/38459273-60c7dc3a-3ab0-11e8-8369-e5a94aa37846.png">

run
```
npm start
npm publish
```

You will see this in Terminal
<img width="1227" alt="screen shot 2018-04-07 at 9 44 00 pm" src="https://user-images.githubusercontent.com/14208343/38459283-7ed9a366-3ab0-11e8-9a68-72dab4e4dfaa.png">

Then apply fix
<img width="1108" alt="screen shot 2018-04-07 at 10 11 17 pm" src="https://user-images.githubusercontent.com/14208343/38459306-b6e78eda-3ab0-11e8-9f67-6b9fd883ef41.png">

run again
```
npm publish
```

You will see this in Terminal
<img width="1116" alt="screen shot 2018-04-07 at 9 36 05 pm" src="https://user-images.githubusercontent.com/14208343/38459391-a5df6800-3ab1-11e8-8d5a-284e8d457e2a.png">


I tested this fix in our project today and all works for image-assets with and without multiple attached files, for fonts, for videos.

<img width="1445" alt="screen shot 2018-04-07 at 10 13 13 pm" src="https://user-images.githubusercontent.com/14208343/38459347-1d389864-3ab1-11e8-9dfe-ba353d34d5d7.png">
