### PR TITLE
Change default behavior to assume configs follow the app.json structure

### DIFF
--- a/src/project/ProjectUtils.js
+++ b/src/project/ProjectUtils.js
@@ -156,7 +156,7 @@ export async function findConfigFileAsync(
     configPath = await _findConfigPathAsync(projectRoot);
   }
   const configName = path.basename(configPath);
-  const configNamespace = configName === 'app.json' ? 'expo' : null;
+  const configNamespace = configName !== 'exp.json' ? 'expo' : null;
   return { configPath, configName, configNamespace };
 }
 
@@ -198,7 +198,6 @@ export async function readConfigJsonAsync(
 
     if (configNamespace) {
       // if we're not using exp.json, then we've stashed everything under an expo key
-      // this is only for app.json at time of writing
       exp = exp[configNamespace];
     }
   } catch (e) {


### PR DESCRIPTION
This PR refactors the `findConfigFileAsync` behavior to assume any file not named `exp.json` uses the newer `app.json` structure. This fix is based on my discussion with @fson on Slack, and you can find more info regarding the current behavior in the issue I opened [here](https://github.com/expo/expo/issues/1688).

Without this change, it is easy to encounter issues when renaming `app.json` or creating multiple config files (e.g. for different envs, etc), and then trying to run `exp start --config <path_to_config_file>`. The current behavior will cause things to break unexpectedly because the default assumption is that anything not named exactly `app.json` is assumed to have the old config structure (i.e. not nested under a key called `expo`).

This PR flips the logic so instead any config is assumed to use the newer `app.json` layout unless the file is explicitly called `exp.json`.