### PR TITLE
Do not overwrite CFBundleDisplayName key if user provided one

### DIFF
--- a/src/detach/IosNSBundle.js
+++ b/src/detach/IosNSBundle.js
@@ -253,7 +253,9 @@ async function _configureInfoPlistAsync(context: StandaloneContext) {
 
     // app name
     infoPlist.CFBundleName = config.name;
-    infoPlist.CFBundleDisplayName = config.name;
+    if (!infoPlist.CFBundleDisplayName) {
+      infoPlist.CFBundleDisplayName = config.name;
+    }
 
     // determine app linking schemes
     let linkingSchemes = config.scheme ? [config.scheme] : [];


### PR DESCRIPTION
Hi. I believe it would be very useful to have an opportunity to provide your own CFBundelDisplayName for standalone builds. It is used on home screen in iOS and sometimes it makes sense to have a shorter version of app name for this.