### PR TITLE
bubble all socket error codes as otherwise some errors are hard to debug

### DIFF
--- a/src/ApiV2.js
+++ b/src/ApiV2.js
@@ -10,8 +10,6 @@ import idx from 'idx';
 
 import Config from './Config';
 
-import logger from './Logger';
-
 import type { User } from './User';
 
 let ROOT_BASE_URL = `${Config.api.scheme}://${Config.api.host}`;
@@ -40,10 +38,6 @@ type RequestOptions = {
 };
 
 type QueryParameters = { [key: string]: ?(string | number | boolean) };
-
-type ErrorWithResponseBody = Error & {
-  responseBody?: any,
-};
 
 type APIV2ClientOptions = {
   sessionSecret?: string,
@@ -179,23 +173,12 @@ export default class ApiV2Client {
       const maybeErrorData = idx(e, _ => _.response.data.errors.length);
       if (maybeErrorData) {
         result = e.response.data;
-      } else if (e.code.match(/E[A-Z]+/)) {
-        // surface network failures
-        throw e;
+        if (!result || typeof result !== 'object') {
+          throw e;
+        }
       } else {
-        const error: ErrorWithResponseBody = new Error(
-          `There was a problem understanding the server. Please try again.`
-        );
-        error.responseBody = result;
-        logger.error(error);
-        throw error;
+        throw e;
       }
-    }
-
-    if (!result || typeof result !== 'object') {
-      let error: ErrorWithResponseBody = new Error(`There was a problem understanding the server.`);
-      error.responseBody = result;
-      throw error;
     }
 
     if (result.errors && result.errors.length) {

--- a/src/ApiV2.js
+++ b/src/ApiV2.js
@@ -179,7 +179,7 @@ export default class ApiV2Client {
       const maybeErrorData = idx(e, _ => _.response.data.errors.length);
       if (maybeErrorData) {
         result = e.response.data;
-      } else if (e.code === 'ECONNREFUSED' || e.code === 'ENOTFOUND' || e.code === 'ETIMEDOUT') {
+      } else if (e.code.match(/E[A-Z]+/)) {
         // surface network failures
         throw e;
       } else {


### PR DESCRIPTION
~~see http://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html for a comprehensive list.~~

~~Using expo in a proxy environment I was only able to see the reason of the network error after I added `e.code === 'EHOSTUNREACH'`. So instead of using a random list of errors selected from the above error list I wrote a quick regex which should match all of these errors above.~~

Updated: Integrated feedback. Now just rethrowing any errors that don't result in a ApiV2Error. 