### PR TITLE
Why is react not a peer dependency ? 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/exponent/xdl/issues"
   },
   "homepage": "https://github.com/exponent/xdl#readme",
+  "peerDependencies": {
+    "react": "^16.0.0",
+  },
   "dependencies": {
     "@expo/bunyan": "3.0.2",
     "@expo/json-file": "^8.0.0",
@@ -76,7 +79,6 @@
     "querystring": "^0.2.0",
     "raven": "^2.1.1",
     "raven-js": "^3.17.0",
-    "react": "^16.0.0",
     "react-redux": "^5.0.2",
     "read-chunk": "^2.0.0",
     "read-last-lines": "^1.6.0",


### PR DESCRIPTION
I have 2 versions of react in my yarn.lock:

- react@16.3.1 : 16.3.1 (version in https://blog.expo.io/expo-sdk-v29-0-0-is-now-available-f001d77fadf)
- react@^16.0.0: 16.4.1 a dependency of xdl, dependency of exp@^55.0.5, dependency of react-native-scripts@1.14.0

Is there a reason why this is a normal dependency ?