### PR TITLE
[detach] Add SKAdNetworkIdentifiers when using expo-ads-facebook or expo-ads-admob

### DIFF
--- a/packages/xdl/src/detach/IosNSBundle.ts
+++ b/packages/xdl/src/detach/IosNSBundle.ts
@@ -416,6 +416,30 @@ async function _configureInfoPlistAsync(context: AnyStandaloneContext): Promise<
       };
     }
 
+    // SDKAdNetwork ids for expo-ads-facebook
+    if (config.dependencies?.includes?.('expo-ads-facebook')) {
+      infoPlist.SKAdNetworkItems = infoPlist.SKAdNetworkItems || [];
+
+      // These are static values from https://developers.facebook.com/docs/SKAdNetwork
+      infoPlist.SKAdNetworkItems.push({
+        SKAdNetworkIdentifier: 'v9wttpbfk9.skadnetwork',
+      });
+
+      infoPlist.SKAdNetworkItems.push({
+        SKAdNetworkIdentifier: 'n38lu8286q.skadnetwork',
+      });
+    }
+
+    // SDKAdNetwork ids for expo-ads-admob
+    if (config.dependencies?.includes?.('expo-ads-admob')) {
+      infoPlist.SKAdNetworkItems = infoPlist.SKAdNetworkItems || [];
+
+      // This is a static value from https://developers.google.com/admob/ios/ios14
+      infoPlist.SKAdNetworkItems.push({
+        SKAdNetworkIdentifier: 'cstr6suwn9.skadnetwork',
+      });
+    }
+
     const permissionsAppName = config.name ? config.name : 'this app';
     for (const key in infoPlist) {
       if (


### PR DESCRIPTION
# Why

This will be needed in SDK 41 apps in order to support iOS 14.5+

# How

Check that the app has a dependency on `expo-ads-facebook` and/or `expo-ads-admob` and add the appropriate keys to Info.plist if so.

 My understanding is that the `config` object here should allow us to access any properties on the manifest, but please correct me if not. I could not find other examples of using the manifest `dependencies` key in related code. ([example manifest](https://exp.host/@react-navigation/NavigationPlayground/index.exp?sdkVersion=39.0.0))

# Test Plan

Run a shell app build with these libraries, inspect the resulting archive to ensure keys are added to Info.plist.