### PR TITLE
Prepare AndroidShellApp for flavors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,6 @@ This is the changelog of the maintenance fork of `xdl`.
 
 ### 🎉 New features
 
+- [xdl] `AndroidShellApp` supports versioning flavors. ([#35](https://github.com/expo/xdl/pull/35) by [@barthap](https://github.com/barthap))
+
 ### 🐛 Bug fixes

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -1636,6 +1636,19 @@ const removeInvalidSdkLinesWhenPreparingShell = async (majorSdkVersion, filePath
 };
 
 async function removeObsoleteSdks(shellPath, requiredSdkVersion) {
+  let multipleVersionReactNativeActivity = path.join(
+    shellPath,
+    'expoview/src/versioned/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java'
+  );
+
+  // fallback to non-versioned for backward compatibility
+  if (!fs.existsSync(multipleVersionReactNativeActivity)) {
+    multipleVersionReactNativeActivity = path.join(
+      shellPath,
+      'expoview/src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java'
+    );
+  }
+
   const filePathsToTransform = {
     // Remove obsolete `expoview-abiXX_X_X` dependencies
     appBuildGradle: path.join(shellPath, 'app/build.gradle'),
@@ -1644,10 +1657,7 @@ async function removeObsoleteSdks(shellPath, requiredSdkVersion) {
     // Remove obsolete includeUnimodulesProjects
     settingsBuildGradle: path.join(shellPath, 'settings.gradle'),
     // Remove no-longer-valid interfaces from MultipleVersionReactNativeActivity
-    multipleVersionReactNativeActivity: path.join(
-      shellPath,
-      'expoview/src/main/java/host/exp/exponent/experience/MultipleVersionReactNativeActivity.java'
-    ),
+    multipleVersionReactNativeActivity,
     // Remove invalid ABI versions from Constants
     constants: path.join(shellPath, 'expoview/src/main/java/host/exp/exponent/Constants.java'),
     // Remove non-existent DevSettingsActivities


### PR DESCRIPTION
# Why

Required change for https://github.com/expo/expo/pull/12917

makes `et android-shell-app` work properly with flavors

# How

Fixed path to versioned file with fallback to existing behavior if it doesnt exist