### PR TITLE
Support to override installing packages when create shell app workspace

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -368,7 +368,8 @@ exports.createAndroidShellAppAsync = async function createAndroidShellAppAsync(a
     /* testEnvironment */ 'none',
     buildFlags,
     url,
-    releaseChannel
+    releaseChannel,
+    null
   );
 
   await copyInitialShellAppFilesAsync(androidSrcPath, shellPath, false, sdkVersion);

--- a/packages/xdl/src/detach/Detach.js
+++ b/packages/xdl/src/detach/Detach.js
@@ -379,6 +379,7 @@ async function prepareDetachedServiceContextIosAsync(projectDir, args) {
     /* testEnvironment */ 'none',
     buildFlags,
     null,
+    null,
     null
   );
   const { iosProjectDirectory, supportingDirectory } = IosWorkspace.getPaths(context);

--- a/packages/xdl/src/detach/IosShellApp.js
+++ b/packages/xdl/src/detach/IosShellApp.js
@@ -211,6 +211,9 @@ async function _createStandaloneContextAsync(args) {
   } else if (privateConfig?.bundleIdentifier) {
     bundleExecutable = pascalCase(privateConfig.bundleIdentifier);
   }
+  const packagesToInstallWhenEjecting = args.packagesToInstallWhenEjecting
+    ? JSON.parse(args.packagesToInstallWhenEjecting)
+    : null;
 
   const buildFlags = StandaloneBuildFlags.createIos(args.configuration, {
     workspaceSourcePath,
@@ -227,7 +230,8 @@ async function _createStandaloneContextAsync(args) {
     buildFlags,
     args.url,
     args.releaseChannel,
-    args.shellAppSdkVersion
+    args.shellAppSdkVersion,
+    packagesToInstallWhenEjecting
   );
   return context;
 }

--- a/packages/xdl/src/detach/IosWorkspace.js
+++ b/packages/xdl/src/detach/IosWorkspace.js
@@ -284,7 +284,14 @@ async function createDetachedAsync(context) {
   }
 
   logger.info('Installing required packages...');
-  await _installRequiredPackagesAsync(projectRootDirectory, standaloneSdkVersion);
+  if (context.type === 'service' && context.data.packagesToInstallWhenEjecting) {
+    await _installEjectingPackagesAsync(
+      projectRootDirectory,
+      context.data.packagesToInstallWhenEjecting
+    );
+  } else {
+    await _installRequiredPackagesAsync(projectRootDirectory, standaloneSdkVersion);
+  }
 
   logger.info('Naming iOS project...');
   await _renameAndMoveProjectFilesAsync(context, iosProjectDirectory, projectName);
@@ -320,6 +327,10 @@ async function _getPackagesToInstallWhenEjecting(sdkVersion) {
 // and not only when ejecting. These copies can be moved to one place if we decide to have just one flow for these two processes.
 async function _installRequiredPackagesAsync(projectRoot, sdkVersion) {
   const packagesToInstallWhenEjecting = await _getPackagesToInstallWhenEjecting(sdkVersion);
+  return _installEjectingPackagesAsync(projectRoot, packagesToInstallWhenEjecting);
+}
+
+async function _installEjectingPackagesAsync(projectRoot, packagesToInstallWhenEjecting) {
   const packagesToInstall = [];
 
   if (packagesToInstallWhenEjecting && typeof packagesToInstallWhenEjecting === 'object') {

--- a/packages/xdl/src/detach/StandaloneContext.ts
+++ b/packages/xdl/src/detach/StandaloneContext.ts
@@ -4,6 +4,8 @@ type StandaloneContextDataType = 'user' | 'service';
 
 type StandaloneContextTestEnvironment = 'none' | 'local' | 'ci';
 
+type OverridenPackagesToInstallWhenEjecting = Record<string, string>;
+
 // currently unused
 export function isStandaloneContextDataUser(value: any): value is StandaloneContextDataUser {
   return value && typeof value.projectPath === 'string' && 'exp' in value;
@@ -44,6 +46,7 @@ export type StandaloneContextDataService = {
   privateConfig: any;
   testEnvironment: StandaloneContextTestEnvironment;
   shellAppSdkVersion: string;
+  packagesToInstallWhenEjecting: OverridenPackagesToInstallWhenEjecting | null;
 };
 
 class StandaloneContext {
@@ -80,7 +83,8 @@ class StandaloneContext {
     build: StandaloneBuildFlags,
     publishedUrl: string,
     releaseChannel: string,
-    shellAppSdkVersion: string
+    shellAppSdkVersion: string,
+    packagesToInstallWhenEjecting: OverridenPackagesToInstallWhenEjecting | null
   ): StandaloneContextService => {
     const context = new StandaloneContextService(
       {
@@ -90,6 +94,7 @@ class StandaloneContext {
         privateConfig,
         testEnvironment,
         shellAppSdkVersion,
+        packagesToInstallWhenEjecting,
       },
       {
         url: publishedUrl,


### PR DESCRIPTION
# Why

Originally, the shell workspace will install packages from `getNewestSdkVersionSupportedAsync` and it requires SDK versioning. During the time of react-native upgrade, we should install newer packages, otherwise CI will break at shell app.

# How

This PR introduces `packagesToInstallWhenEjecting` argument in ios shell workspace to override the packages to install. 

# Test Plan

Test with expotool:
`et ios-shell-app -a build --type simulator --shellAppSdkVersion UNVERSIONED -v true --skipRepoUpdate` should not breaking.

`et ios-shell-app -a build --type simulator --shellAppSdkVersion UNVERSIONED -v true --skipRepoUpdate --packagesToInstallWhenEjecting '{"react-native": "git://github.com/expo/react-native.git#sdk-43", "react-native-unimodules": "0.14.1"}'` should install react-native from our fork