### PR TITLE
[android] add ACCESS_MEDIA_LOCATION to blacklist for android permissions

### DIFF
--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -941,6 +941,8 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       'android.permission.USE_FINGERPRINT', // expo-local-authentication
       'android.permission.USE_BIOMETRIC', // expo-local-authentication
       'android.permission.VIBRATE', // expo-haptics
+      'android.permission.ACCESS_MEDIA_LOCATION', // android-media-library
+
 
       // react native debugging permissions - not required for standalone apps
       'android.permission.READ_PHONE_STATE',

--- a/packages/xdl/src/detach/AndroidShellApp.js
+++ b/packages/xdl/src/detach/AndroidShellApp.js
@@ -943,7 +943,6 @@ export async function runShellAppModificationsAsync(context, sdkVersion, buildMo
       'android.permission.VIBRATE', // expo-haptics
       'android.permission.ACCESS_MEDIA_LOCATION', // android-media-library
 
-
       // react native debugging permissions - not required for standalone apps
       'android.permission.READ_PHONE_STATE',
       'android.permission.SYSTEM_ALERT_WINDOW',


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

related to this PR: https://github.com/expo/expo/pull/14413

Adding this permission to Expo Go to enable location exif data for Android 10+

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Adding the string to this blacklist to be stripped unless otherwise specified by a given Expo project

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

I would like feedback on how to test this - I think producing a build and inspecting the permissions / manifest would be the best way