### PR TITLE
[xdl] disable managed versions in xcode 13

### DIFF
--- a/packages/xdl/src/detach/IosCodeSigning.js
+++ b/packages/xdl/src/detach/IosCodeSigning.js
@@ -87,6 +87,8 @@ const createExportOptionsPlist = ({
     <string>${exportMethod}</string>
     <key>teamID</key>
     <string>${teamID}</string>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
     <key>provisioningProfiles</key>
     <dict>
       <key>${bundleIdentifier}</key>


### PR DESCRIPTION
# Why

xcode 13 automatic version management by default
https://github.com/fastlane/fastlane/issues/19352

# How

- disable it in export options

# Test Plan

TODO