### PR TITLE
[xdl] switch cloudfront domain to classic-assets.eascdn.net

### DIFF
--- a/packages/xdl/src/ProjectAssets.ts
+++ b/packages/xdl/src/ProjectAssets.ts
@@ -18,7 +18,7 @@ import UserManager from './User';
 import * as ExpSchema from './project/ExpSchema';
 import * as ProjectUtils from './project/ProjectUtils';
 
-const EXPO_CDN = 'https://d1wp6m56sqw74a.cloudfront.net';
+const EXPO_CDN = 'https://classic-assets.eascdn.net';
 
 type ManifestAsset = { fileHashes: string[]; files: string[]; hash: string };
 

--- a/packages/xdl/src/detach/AssetBundle.ts
+++ b/packages/xdl/src/detach/AssetBundle.ts
@@ -9,7 +9,7 @@ import { saveUrlToPathAsync } from './ExponentTools';
 import { AnyStandaloneContext } from './StandaloneContext';
 
 const EXPO_DOMAINS = ['expo.io', 'exp.host', 'expo.test', 'localhost'];
-export const DEFAULT_CDN_HOST = 'https://d1wp6m56sqw74a.cloudfront.net';
+export const DEFAULT_CDN_HOST = 'https://classic-assets.eascdn.net';
 export const ASSETS_DIR_DEFAULT_URL = `${DEFAULT_CDN_HOST}/~assets`;
 
 type UrlResolver = (hash: string) => string;


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
This PR swaps out the hard coded `d1wp6m56sqw74a.cloudfront.net` cdn with `classic-assets.eascdn.net`

Replacing domains will help us gradually shift traffic away from CloudFront to Cloudflare if we wanted to. However, we make assumptions, including in shipped client code in end-user apps, about https://d1wp6m56sqw74a.cloudfront.net. 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->