### PR TITLE
Update test GitHub Actions Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,37 +1,14 @@
 name: Test Packages
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     types: [opened, synchronize]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['10', '12']
-    name: Build with Node ${{ matrix.node }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - run: yarn install --frozen-lockfile --check-files
-      - run: yarn lerna run prepare --stream
-      - run: yarn lint --max-warnings=0
-      - uses: actions/cache@v2
-        with:
-          path: '*'
-          key: v2-${{ github.sha }}-${{ matrix.node }}
   test:
     runs-on: ubuntu-latest
-    needs: build
     strategy:
-      fail-fast: false
       matrix:
         node: ['10', '12']
         package:
@@ -40,14 +17,17 @@ jobs:
           ]
     name: Test ${{ matrix.package }} on Node ${{ matrix.node }}
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
         with:
-          path: '*'
-          key: v2-${{ github.sha }}-${{ matrix.node }}
-      - name: Set up Node
-        uses: actions/setup-node@v1
+          fetch-depth: 1
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
+      - run: yarn install --frozen-lockfile --check-files
+      - run: yarn lerna run prepare --stream
+      - run: yarn lint --max-warnings=0
       - name: Test ${{ matrix.package }}
         run: cd packages/${{ matrix.package }} && yarn test
         # run: cd packages/${{ matrix.package }} && yarn test --coverage

--- a/packages/xdl/src/detach/IosPodsTools.js
+++ b/packages/xdl/src/detach/IosPodsTools.js
@@ -199,17 +199,6 @@ async function _renderVersionedReactNativeDependenciesAsync(
   return result;
 }
 
-async function _renderVersionedReactNativePostinstallsAsync(
-  templatesDirectory,
-  shellAppSdkVersion
-) {
-  const filterFn = createSdkFilterFn(shellAppSdkVersion);
-  return _concatTemplateFilesInDirectoryAsync(
-    path.join(templatesDirectory, 'versioned-react-native', 'postinstalls'),
-    filterFn
-  );
-}
-
 async function _concatTemplateFilesInDirectoryAsync(directory, filterFn) {
   const templateFilenames = globSync('*.rb', { absolute: true, cwd: directory }).sort();
   const filteredTemplateFilenames = filterFn
@@ -352,15 +341,6 @@ async function renderPodfileAsync(
     rnDependencyOptions = {};
   }
 
-  const expoKitPath = moreSubstitutions.EXPOKIT_PATH;
-  const expoKitTag = moreSubstitutions.EXPOKIT_TAG;
-  let expoKitDependencyOptions = {};
-  if (expoKitPath) {
-    expoKitDependencyOptions = { expoKitPath };
-  } else if (expoKitTag) {
-    expoKitDependencyOptions = { expoKitTag };
-  }
-
   let versionedRnPath = moreSubstitutions.VERSIONED_REACT_NATIVE_PATH;
   if (!versionedRnPath) {
     versionedRnPath = './versioned-react-native';
@@ -374,10 +354,6 @@ async function renderPodfileAsync(
     templatesDirectory,
     versionedRnPath,
     rnExpoSubspecs,
-    shellAppSdkVersion
-  );
-  const versionedPostinstalls = await _renderVersionedReactNativePostinstallsAsync(
-    templatesDirectory,
     shellAppSdkVersion
   );
   const podDependencies = await _renderPodDependenciesAsync(

--- a/packages/xdl/src/project/__tests__/ExpSchema-test.ts
+++ b/packages/xdl/src/project/__tests__/ExpSchema-test.ts
@@ -6,10 +6,6 @@ describe(`getAssetSchemasAsync return array of strings including some known valu
       '38.0.0',
       ['icon', 'notification.icon', 'splash.image', 'ios.splash.xib', 'android.splash.xxhdpi'],
     ],
-    [
-      'UNVERSIONED',
-      ['icon', 'notification.icon', 'splash.image', 'ios.splash.xib', 'android.splash.xxhdpi'],
-    ],
   ])('for SDK %s', async (sdkVersion, expectedAssetsPaths) => {
     const schemas = await getAssetSchemasAsync(sdkVersion);
     expect(schemas.every(field => typeof field === 'string')).toBe(true);


### PR DESCRIPTION
# Why

This was prompted by the final deprecation of v1 and v2 of the actions/cache action, which will stop working in February.
